### PR TITLE
id:86061 fix(corejs): move core-js to devDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
-## Unreleased - [DIFF](https://github.com/ElateralLtd/ui-components/compare/v0.1.0...HEAD)
+## Unreleased - [DIFF](https://github.com/ElateralLtd/ui-components/compare/v0.1.1...HEAD)
+
+## 0.1.1 - 2019-06-11 - [DIFF](https://github.com/ElateralLtd/ui-components/compare/v0.1.0...v0.1.1)
+- move `core-js` dependency to `devDependencies`
 
 ## 0.1.0 - 2019-06-10
 - Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elateral/brandgility-embedded-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Brandgility embedded mode library",
   "repository": "https://github.com/ElateralLtd/brandgility-embedded-api.git",
   "main": "lib/brandgility-embedded-api.js",
@@ -45,6 +45,7 @@
     "babel-loader": "^8.0.4",
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "concurrently": "^4.1.0",
+    "core-js": "^3.1.3",
     "coveralls": "^3.0.3",
     "dotenv": "^7.0.0",
     "eslint": "^5.16.0",
@@ -62,8 +63,5 @@
     "unused-files-webpack-plugin": "^3.4.0",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.1"
-  },
-  "dependencies": {
-    "core-js": "^3.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2096,7 +2096,7 @@ core-js@^2.4.0, core-js@^2.5.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
-core-js@^3.0.1:
+core-js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.3.tgz#95700bca5f248f5f78c0ec63e784eca663ec4138"
   integrity sha512-PWZ+ZfuaKf178BIAg+CRsljwjIMRV8MY00CbZczkR6Zk5LfkSkjGoaab3+bqRQWVITNZxQB7TFYz+CFcyuamvA==


### PR DESCRIPTION
## 0.1.1 - 2019-06-11 - [DIFF](https://github.com/ElateralLtd/ui-components/compare/v0.1.0...v0.1.1)
- move `core-js` dependency to `devDependencies`